### PR TITLE
Problem with regexp param protection

### DIFF
--- a/lib/param_protected/protector.rb
+++ b/lib/param_protected/protector.rb
@@ -186,7 +186,7 @@ module ParamProtected
       else
         raise ArgumentError, "unexpected exclusivity: #{exclusivity}"
       end
-      params.each{ |k, v| filter_params(protected_params[k], v, exclusivity) }
+      params.each{ |k, v| filter_params(find_by_key(protected_params, k), v, exclusivity) }
       params
     end
 

--- a/test/users_controller_test.rb
+++ b/test/users_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UsersControllerTest < ActionController::TestCase
   PARAMS = { :user => { :id => 123,
-                        '33' => 'ok',
+                        '33' => { :ok => 'yes', :not_ok => 'no' },
                         '123' => 'ok',
                         :x21 => 'ok',
                         :name => { :first => "chris", :middle => "james", :last => "bottaro"},
@@ -10,7 +10,7 @@ class UsersControllerTest < ActionController::TestCase
              :something => "something" }
              
   EXPECTED_PARAMS = { "user" => { "name" => {"first" => "chris", "last" => "bottaro"},
-                                  '33' => 'ok', '123' => 'ok',
+                                  '33' => { 'ok' => 'yes' }, '123' => 'ok',
                                   "email" => "cjbottaro@blah.com" } }
   
   def test_create


### PR DESCRIPTION
Hi Christopher,

I have just committed a small fix for regexp based param protection. Without it, hashes nested in regexp params could get through unfiltered! It would be great if you'd pull it from me :-)

All the best
Moritz
