### PR TITLE
updated param_* methods to have the same signature as attr_* methods

### DIFF
--- a/lib/param_protected/controller_modifications.rb
+++ b/lib/param_protected/controller_modifications.rb
@@ -12,11 +12,13 @@ module ParamProtected
     
     module ClassMethods
       
-      def param_protected(params, actions = nil)
+      def param_protected(*params)
+		actions = params.extract_options!
         Protector.instance(self).declare_protection(params, actions, BLACKLIST)
       end
       
-      def param_accessible(params, actions = nil)
+      def param_accessible(*params)
+		actions = params.extract_options!
         Protector.instance(self).declare_protection(params, actions, WHITELIST)
       end
 


### PR DESCRIPTION
updated param_\* method signatures to be the same as attr_\* methods, accepting a list of property names instead of an array, followed by an options hash
